### PR TITLE
Add populated ARLAS collection for integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# ARLAS-subscriptions
+
+[![Build Status](https://api.travis-ci.org/gisaia/ARLAS-subscriptions.svg?branch=develop)](https://travis-ci.org/gisaia/ARLAS-subscriptions)
+
+## Build
+
+```sh
+mvn clean package
+```
+
+## Run
+
+```sh
+docker-compose up -d
+```
+
+## Integration tests
+#### Run test suite
+
+```sh
+./scripts/tests-integration.sh
+```
+
+#### Start test stack populated with test datasets
+
+```sh
+./scripts/tests-stack.sh
+```

--- a/arlas-subscriptions-matcher/pom.xml
+++ b/arlas-subscriptions-matcher/pom.xml
@@ -14,26 +14,6 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <properties>
-        <kafka.version>2.1.1</kafka.version>
-        <cyclops.version>10.3.2</cyclops.version>
-        <maven-shade-plugin.version>3.2.1</maven-shade-plugin.version>
-        <arlas.version>11.6.0</arlas.version>
-    </properties>
-    <repositories>
-        <repository>
-            <id>gisaia-public</id>
-            <url>https://dl.cloudsmith.io/public/gisaia/public/maven</url>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </snapshots>
-        </repository>
-    </repositories>
     <dependencies>
         <dependency>
             <groupId>io.arlas</groupId>

--- a/arlas-subscriptions-tests/pom.xml
+++ b/arlas-subscriptions-tests/pom.xml
@@ -16,14 +16,43 @@
         <org.hamcrest.version>1.3</org.hamcrest.version>
         <io.rest-assured.version>3.3.0</io.rest-assured.version>
         <junit.version>4.12</junit.version>
+        <geojson.jackson.version>1.8.1</geojson.jackson.version>
     </properties>
 
     <dependencies>
+        <!-- ____________________________________________________ -->
+        <!-- ARLAS -->
+        <!-- ____________________________________________________ -->
         <dependency>
             <groupId>io.arlas</groupId>
             <artifactId>arlas-subscriptions-manager</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>${pom.parent.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.arlas</groupId>
+            <artifactId>arlas-server-client</artifactId>
+            <version>${arlas.version}</version>
+        </dependency>
+
+        <!-- ____________________________________________________ -->
+        <!-- GEO -->
+        <!-- ____________________________________________________ -->
+        <dependency>
+            <groupId>de.grundid.opendatalab</groupId>
+            <artifactId>geojson-jackson</artifactId>
+            <version>${geojson.jackson.version}</version>
+        </dependency>
+
+        <!-- ____________________________________________________ -->
+        <!-- Backends -->
+        <!-- ____________________________________________________ -->
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>transport</artifactId>
+            <version>${elastic.version}</version>
+        </dependency>
+
         <!-- ____________________________________________________ -->
         <!-- Tests -->
         <!-- ____________________________________________________ -->

--- a/arlas-subscriptions-tests/src/test/java/io/arlas/subscriptions/AbstractTestContext.java
+++ b/arlas-subscriptions-tests/src/test/java/io/arlas/subscriptions/AbstractTestContext.java
@@ -49,7 +49,5 @@ public abstract class AbstractTestContext {
         if (!arlasSubManagerAppPath.endsWith("/"))
             arlasSubManagerPath = arlasSubManagerPath + "/";
         LOGGER.info(arlasSubManagerPath);
-
-
     }
 }

--- a/arlas-subscriptions-tests/src/test/java/io/arlas/subscriptions/AbstractTestWithData.java
+++ b/arlas-subscriptions-tests/src/test/java/io/arlas/subscriptions/AbstractTestWithData.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.subscriptions;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+
+public abstract class AbstractTestWithData extends AbstractTestContext {
+
+
+    @BeforeClass
+    public static void beforeClass() {
+        try {
+            DataSetTool.loadDataSet();
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            Thread.sleep(10000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        DataSetTool.clearDataSet();
+        DataSetTool.close();
+    }
+}

--- a/arlas-subscriptions-tests/src/test/java/io/arlas/subscriptions/Data.java
+++ b/arlas-subscriptions-tests/src/test/java/io/arlas/subscriptions/Data.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.subscriptions;
+
+import org.geojson.Polygon;
+
+public class Data {
+    public String id;
+    public String fullname;
+    public DataParams params = new DataParams();
+    public GeometryParams geo_params = new GeometryParams();
+
+    public class DataParams {
+        public String job;
+        public int age;
+        public Integer weight;
+        public String city;
+        public String country;
+        public Long startdate;
+        public Long stopdate;
+    }
+
+    public class GeometryParams {
+        public Polygon geometry;
+        public String centroid;
+    }
+}

--- a/arlas-subscriptions-tests/src/test/java/io/arlas/subscriptions/DataSetTool.java
+++ b/arlas-subscriptions-tests/src/test/java/io/arlas/subscriptions/DataSetTool.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.subscriptions;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.squareup.okhttp.Call;
+import com.squareup.okhttp.Response;
+import io.arlas.client.ApiClient;
+import io.arlas.client.ApiException;
+import io.arlas.client.Pair;
+import io.arlas.client.model.CollectionReferenceParameters;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.client.AdminClient;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.transport.client.PreBuiltTransportClient;
+import org.geojson.LngLatAlt;
+import org.geojson.Polygon;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.util.*;
+
+public class DataSetTool {
+    static Logger LOGGER = LoggerFactory.getLogger(DataSetTool.class);
+
+    public static String COLLECTION_NAME = "geodata";
+
+    public final static String DATASET_INDEX_NAME = "dataset";
+    public final static String DATASET_TYPE_NAME = "mytype";
+    public final static String DATASET_ID_PATH = "id";
+    public final static String DATASET_GEOMETRY_PATH = "geo_params.geometry";
+    public final static String DATASET_CENTROID_PATH = "geo_params.centroid";
+    public final static String DATASET_TIMESTAMP_PATH = "params.startdate";
+    public static final String[] jobs = {"Actor", "Announcers", "Archeologists", "Architect", "Brain Scientist", "Chemist", "Coach", "Coder", "Cost Estimator", "Dancer", "Drafter"};
+    public static final String[] cities = {"Paris", "London", "New York", "Tokyo", "Toulouse", "Marseille", "Lyon", "Bordeaux", "Lille", "Albi", "Calais"};
+    public static final String[] countries = {"Afghanistan",
+            "Albania",
+            "Algeria",
+            "Andorra",
+            "Angola",
+            "Antigua",
+            "Barbuda",
+            "Argentina",
+            "Armenia",
+            "Aruba",
+            "Australia",
+            "Austria"
+    };
+
+    public static ApiClient apiClient;
+    public static AdminClient adminClient;
+    public static Client client;
+
+    public static ApiClient getApiClient() {
+        return apiClient;
+    }
+
+    static {
+        try {
+            // ARLAS Client
+            String arlasHost = Optional.ofNullable(System.getenv("ARLAS_HOST")).orElse("localhost");
+            int arlasPort = Integer.valueOf(Optional.ofNullable(System.getenv("ARLAS_PORT")).orElse("9999"));
+            String arlasPrefix = Optional.ofNullable(System.getenv("ARLAS_PREFIX")).orElse("/arlas");
+            apiClient = new ApiClient().setBasePath("http://"+arlasHost+":"+arlasPort+arlasPrefix);
+
+            //ES Client
+            Settings settings = null;
+            String elasticHost = Optional.ofNullable(System.getenv("ARLAS_ELASTIC_HOST")).orElse("localhost");
+            int elasticPort = Integer.valueOf(Optional.ofNullable(System.getenv("ARLAS_ELASTIC_PORT")).orElse("9300"));
+            if ("localhost".equals(elasticHost)) {
+                settings = Settings.EMPTY;
+            } else {
+                settings = Settings.builder().put("cluster.name", "elasticsearch").build();
+            }
+            client = new PreBuiltTransportClient(settings)
+                    .addTransportAddress(new TransportAddress(InetAddress.getByName(elasticHost), elasticPort));
+            adminClient = client.admin();
+            LOGGER.info("Load data in " + elasticHost + ":" + elasticPort);
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage(), e);
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        DataSetTool.loadDataSet();
+    }
+
+    public static void loadDataSet() throws IOException {
+        //Create a single index with all data
+        createIndex(DATASET_INDEX_NAME, "dataset.mapping.json");
+        LOGGER.info("Index " + DATASET_INDEX_NAME + " created in Elasticsearch");
+        fillIndex(DATASET_INDEX_NAME, -170, 170, -80, 80);
+        LOGGER.info("Index " + DATASET_INDEX_NAME + " populated in Elasticsearch");
+
+
+        //Create collection in ARLAS-server
+        CollectionReferenceParameters collection = new CollectionReferenceParameters();
+        collection.setIndexName(DataSetTool.DATASET_INDEX_NAME);
+        collection.setTypeName(DataSetTool.DATASET_TYPE_NAME);
+        collection.setIdPath(DataSetTool.DATASET_ID_PATH);
+        collection.setGeometryPath(DataSetTool.DATASET_GEOMETRY_PATH);
+        collection.setCentroidPath(DataSetTool.DATASET_CENTROID_PATH);
+        collection.setTimestampPath(DataSetTool.DATASET_TIMESTAMP_PATH);
+        Call collectionPut = null;
+        try {
+            collectionPut = apiClient.buildCall("/collections/"+COLLECTION_NAME, "PUT", new ArrayList<Pair>(),
+                    new ArrayList<>(), collection, new HashMap<>(), new HashMap<>(), new String[0], null);
+            Response collectionPutResponse = collectionPut.execute();
+            if(collectionPutResponse.code() == 200) {
+                LOGGER.debug("Collection " + COLLECTION_NAME + " created in ARLAS-server : " + collectionPutResponse.message());
+            } else {
+                LOGGER.debug("Collection " + COLLECTION_NAME + " NOT created to ARLAS-server [" + collectionPutResponse.code() + "] : " +
+                        collectionPutResponse.message());
+            }
+        } catch (ApiException e) {
+            LOGGER.error("Unable to create collection in ARLAS-server",e);
+        }
+    }
+
+    private static void createIndex(String indexName, String mappingFileName) throws IOException {
+        String mapping = getString(DataSetTool.class.getClassLoader().getResourceAsStream(mappingFileName));
+        try {
+            adminClient.indices().prepareDelete(indexName).get();
+        } catch (Exception e) {
+        }
+        adminClient.indices().prepareCreate(indexName).addMapping(DATASET_TYPE_NAME, mapping, XContentType.JSON).get();
+    }
+
+    private static void fillIndex(String indexName, int lonMin, int lonMax, int latMin, int latMax) throws JsonProcessingException {
+        Data data;
+        ObjectMapper mapper = new ObjectMapper();
+
+        for (int i = lonMin; i <= lonMax; i += 10) {
+            for (int j = latMin; j <= latMax; j += 10) {
+                data = new Data();
+                data.id = String.valueOf("ID_" + i + "_" + j + "DI").replace("-", "_");
+                data.fullname = "My name is " + data.id;
+                data.params.age = Math.abs(i * j);
+                data.params.startdate = 1l * (i + 1000) * (j + 1000);
+                if (data.params.startdate >= 1013600) {
+                    data.params.weight = (i + 10) * (j + 10);
+                }
+                data.params.stopdate = 1l * (i + 1000) * (j + 1000) + 100;
+                data.geo_params.centroid = j + "," + i;
+                data.params.job = jobs[((Math.abs(i) + Math.abs(j)) / 10) % (jobs.length - 1)];
+                data.params.country = countries[((Math.abs(i) + Math.abs(j)) / 10) % (countries.length - 1)];
+                data.params.city = cities[((Math.abs(i) + Math.abs(j)) / 10) % (cities.length - 1)];
+                List<LngLatAlt> coords = new ArrayList<>();
+                coords.add(new LngLatAlt(i - 1, j + 1));
+                coords.add(new LngLatAlt(i + 1, j + 1));
+                coords.add(new LngLatAlt(i + 1, j - 1));
+                coords.add(new LngLatAlt(i - 1, j - 1));
+                coords.add(new LngLatAlt(i - 1, j + 1));
+                data.geo_params.geometry = new Polygon(coords);
+
+                IndexResponse response = client.prepareIndex(indexName, DATASET_TYPE_NAME, "ES_ID_TEST" + data.id)
+                        .setSource(mapper.writer().writeValueAsString(data), XContentType.JSON)
+                        .get();
+            }
+        }
+    }
+
+    public static void clearDataSet() {
+        adminClient.indices().prepareDelete(DATASET_INDEX_NAME).get();
+    }
+
+    public static void close() {
+        client.close();
+    }
+
+    public static String getString(InputStream is) throws IOException {
+
+        String text = null;
+        try (Scanner scanner = new Scanner(is)) {
+            text = scanner.useDelimiter("\\A").next();
+        }
+
+        return text;
+    }
+}

--- a/arlas-subscriptions-tests/src/test/java/io/arlas/subscriptions/DummyIT.java
+++ b/arlas-subscriptions-tests/src/test/java/io/arlas/subscriptions/DummyIT.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.subscriptions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.squareup.okhttp.Call;
+import com.squareup.okhttp.Response;
+import io.arlas.client.Pair;
+import io.arlas.client.model.Hits;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+
+public class DummyIT extends AbstractTestWithData {
+
+    final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void testArlasCollection() throws Exception {
+
+        //SEARCH REQUEST
+        Call searchCall = DataSetTool.getApiClient().buildCall("/explore/"+DataSetTool.COLLECTION_NAME+"/_search", "GET", new ArrayList<Pair>(),
+                new ArrayList<>(), null, new HashMap<>(), new HashMap<>(), new String[0], null);
+        Response searchResponse = searchCall.execute();
+        String body = searchResponse.body().string();
+        Hits hits = objectMapper.readValue(body, Hits.class);
+
+        Assert.assertThat("Search response is 200",
+                searchResponse.code(),
+                Matchers.equalTo(200));
+        Assert.assertThat("Search response returns 10 hits",
+                hits.getNbhits(),
+                Matchers.equalTo(10l));
+        Assert.assertThat("Search response has 595 hits",
+                hits.getTotalnb(),
+                Matchers.equalTo(595l));
+    }
+}

--- a/arlas-subscriptions-tests/src/test/resources/dataset.mapping.json
+++ b/arlas-subscriptions-tests/src/test/resources/dataset.mapping.json
@@ -1,0 +1,50 @@
+{
+  "_source": {
+    "enabled": true
+  },
+  "dynamic": false,
+  "properties": {
+    "id": {
+      "type": "keyword"
+    },
+    "fullname": {
+      "type": "text"
+    },
+    "params": {
+      "properties": {
+        "age": {
+          "type": "integer"
+        },
+        "weight": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "keyword"
+        },
+        "job": {
+          "type": "keyword"
+        },
+        "city": {
+          "type": "keyword"
+        },
+        "country": {
+          "type": "keyword"
+        },
+        "startdate": {
+          "type": "date",
+          "format": "epoch_millis"
+        }
+      }
+    },
+    "geo_params": {
+      "properties": {
+        "geometry": {
+          "type": "geo_shape"
+        },
+        "centroid": {
+          "type": "geo_point"
+        }
+      }
+    }
+  }
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,8 +41,6 @@ services:
     cap_add:
       - ALL
     privileged: true
-    volumes:
-      - /var/lib/elasticsearch:/usr/share/elasticsearch/data
     ports:
       - 9200:9200
       - 9300:9300
@@ -58,7 +56,7 @@ services:
   #########
 
   arlas-server:
-    image: gisaia/arlas-server:10.6.1
+    image: gisaia/arlas-server:11.6.0
     container_name: "arlas-server"
     ports:
       - 9999:9999

--- a/pom.xml
+++ b/pom.xml
@@ -21,10 +21,32 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <skipTests>true</skipTests>
         <surefire.version>2.20.1</surefire.version>
+        <maven-shade-plugin.version>3.2.1</maven-shade-plugin.version>
+        <cyclops.version>10.3.2</cyclops.version>
+
+        <!-- BACKENDS -->
+        <elastic.version>6.8.1</elastic.version>
+        <kafka.version>2.1.1</kafka.version>
+        <arlas.version>11.6.0</arlas.version>
 
         <!-- REST AND DROPWIZARD-->
         <dropwizard.version>1.3.12</dropwizard.version>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>gisaia-public</id>
+            <url>https://dl.cloudsmith.io/public/gisaia/public/maven</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
+        </repository>
+    </repositories>
 
     <dependencies>
         <dependency>

--- a/scripts/tests-integration-stage.sh
+++ b/scripts/tests-integration-stage.sh
@@ -75,5 +75,22 @@ function test_manager() {
 
 }
 
+function test_dummy() {
+        start_stack
+        docker run --rm \
+            -w /opt/maven \
+            -v $PWD:/opt/maven \
+            -v $HOME/.m2:/root/.m2 \
+            -e ARLAS_HOST="arlas-server" \
+            -e ARLAS_PORT="9999" \
+            -e ARLAS_ELASTIC_HOST="elasticsearch" \
+            -e ARLAS_ELASTIC_PORT="9300" \
+            --net arlas-subscriptions_default \
+            maven:3.5.0-jdk-8 \
+            mvn -Dit.test=DummyIT verify -DskipTests=false  -DfailIfNoTests=false
+
+}
+
 echo "===> run integration tests"
 if [ "$STAGE" == "MANAGER" ]; then test_manager; fi
+if [ "$STAGE" == "DUMMY" ]; then test_dummy; fi

--- a/scripts/tests-integration.sh
+++ b/scripts/tests-integration.sh
@@ -20,3 +20,4 @@ cd ${SCRIPT_PATH}/..
 
 # TESTS SUITE
 ./scripts/tests-integration-stage.sh --stage=MANAGER
+./scripts/tests-integration-stage.sh --stage=DUMMY

--- a/scripts/tests-stack.sh
+++ b/scripts/tests-stack.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+
+function clean_docker {
+    ./scripts/docker-clean.sh
+    echo "===> clean maven repository"
+	docker run --rm \
+		-w /opt/maven \
+		-v $PWD:/opt/maven \
+		-v $HOME/.m2:/root/.m2 \
+		maven:3.5.0-jdk-8 \
+		mvn clean
+}
+
+function clean_exit {
+    ARG=$?
+	echo "===> Exit stage ${STAGE} = ${ARG}"
+    exit $ARG
+}
+trap clean_exit EXIT
+
+
+# GO TO PROJECT PATH
+SCRIPT_PATH=`cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd`
+cd ${SCRIPT_PATH}/..
+
+
+function start_stack() {
+    # START STACK
+    ./scripts/docker-clean.sh
+    ./scripts/docker-run.sh --stage=ALL --build
+}
+
+
+start_stack
+
+echo "===> load test dataset"
+docker run --rm \
+    -w /opt/maven \
+    -v $PWD:/opt/maven \
+    -v $HOME/.m2:/root/.m2 \
+    -e ARLAS_HOST="arlas-server" \
+    -e ARLAS_PORT="9999" \
+    -e ARLAS_ELASTIC_HOST="elasticsearch" \
+    -e ARLAS_ELASTIC_PORT="9300" \
+    --net arlas-subscriptions_default \
+    maven:3.5.0-jdk-8 \
+    mvn exec:java -Dexec.mainClass="io.arlas.subscriptions.DataSetTool" -Dexec.classpathScope=test -pl arlas-subscriptions-tests
+
+echo "===> Enjoy arlas-server API on http://localhost:9999/arlas/swagger"


### PR DESCRIPTION
First stage of #7 with an ARLAS-server populated with a collection called `geodata` (identical to the one used in ARLAS-server test suite).

A future PR will populate a subscription collection in ARLAS-server and add some documentation about this test dataset.