### PR TITLE
Print containers logs in case of error

### DIFF
--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -22,6 +22,15 @@ done
 
 function clean_exit {
     ARG=$?
+
+    # Allow errors on cleanup
+    set +e
+
+    if [[ "$ARG" != 0 ]]; then
+        # In case of error, print containers logs (if any)
+        docker-compose logs
+    fi
+
     exit $ARG
 }
 


### PR DESCRIPTION
Example usage: https://travis-ci.com/gisaia/ARLAS-subscriptions/builds/121415196