### PR TITLE
Add populated ARLAS collection for subscriptions in integration tests

### DIFF
--- a/arlas-subscriptions-common/pom.xml
+++ b/arlas-subscriptions-common/pom.xml
@@ -23,7 +23,12 @@
             <artifactId>java-uuid-generator</artifactId>
             <version>${jug.version}</version>
         </dependency>
-
+        <!-- GEO JSON -->
+        <dependency>
+            <groupId>de.grundid.opendatalab</groupId>
+            <artifactId>geojson-jackson</artifactId>
+            <version>${geojson.jackson.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/arlas-subscriptions-common/src/main/java/io/arlas/subscriptions/model/IndexedUserSubscription.java
+++ b/arlas-subscriptions-common/src/main/java/io/arlas/subscriptions/model/IndexedUserSubscription.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.subscriptions.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.geojson.GeoJsonObject;
+import org.hibernate.validator.constraints.NotEmpty;
+
+public class IndexedUserSubscription extends UserSubscription {
+    @NotEmpty
+    @JsonProperty(required = true)
+    public GeoJsonObject geometry;
+
+    @NotEmpty
+    @JsonProperty(required = true)
+    public String centroid;
+}

--- a/arlas-subscriptions-manager/src/main/resources/arlas.sub.mapping.json
+++ b/arlas-subscriptions-manager/src/main/resources/arlas.sub.mapping.json
@@ -29,7 +29,7 @@
       "type": "date"
     },
     "title": {
-      "type": "boolean"
+      "type": "text"
     },
     "subscription": {
       "properties": {

--- a/arlas-subscriptions-tests/README.md
+++ b/arlas-subscriptions-tests/README.md
@@ -1,0 +1,148 @@
+# INTEGRATION TESTS DATASETS
+
+All data is indexed with [DataSetTool](src/test/java/io/arlas/subscriptions/DataSetTool.java) or by extending [AbstractTestWithData](src/test/java/io/arlas/subscriptions/AbstractTestWithData.java).
+
+You can have a closer look to this dataset by running `./scripts/tests-stack.sh` and browse :
+* [http://localhost:9999/arlas/swagger#/]()
+* [http://localhost:9200/dataset/_search]()
+* [http://localhost:9200/subs/_search]()
+
+## Documents collection
+
+#### Document example
+@see [Mapping](src/test/resources/dataset.mapping.json)
+```json
+  {
+    "id": "ID__170__20DI",
+    "fullname": "My name is ID__170__20DI",
+    "params": {
+      "country": "Armenia",
+      "city": "Albi",
+      "job": "Dancer",
+      "startdate": 813400,
+      "stopdate": 813500,
+      "age": 3400
+    },
+    "geo_params": {
+      "centroid": "-20,-170",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              -171,
+              -19
+            ],
+            [
+              -169,
+              -19
+            ],
+            [
+              -169,
+              -21
+            ],
+            [
+              -171,
+              -21
+            ],
+            [
+              -171,
+              -19
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      }
+    }
+  }
+```
+
+#### Collection description
+```json
+{
+  "collection_name": "geodata",
+  "params": {
+    "index_name": "dataset",
+    "type_name": "mytype",
+    "id_path": "id",
+    "geometry_path": "geo_params.geometry",
+    "centroid_path": "geo_params.centroid",
+    "timestamp_path": "params.startdate"
+  }
+}
+```
+
+## Subscriptions collection
+
+#### Subscription
+@see [Mapping](src/test/resources/subscriptions.mapping.json)
+
+Only one subscription is indexed in subscription collection.
+
+```json
+{
+  "id":"1234",
+  "modified_at":-1,
+  "created_by_admin":false,
+  "created_at":1564578988,
+  "active":true,
+  "title":"Test Subscription",
+  "created_by":"gisaia",
+  "deleted":false,
+  "expires_at":-1,
+  "subscription":{
+    "trigger":{
+      "geometry":"POLYGON((-50 50,50 50,50 -50,-50 -50,-50 50))",
+      "job":"[Actor, Announcers, Archeologists, Architect, Brain Scientist]",
+      "event":"[UPDATE]"
+    },
+    "hits":{
+      "filter":"f=params.city:eq:Toulouse",
+      "projection":"exclude=params.country"
+    },
+    "callback":"http://myservice.com/mycallback"
+  },
+  "userMetadatas":{
+    "correlationId":"my-correlation-id"
+  },
+  "centroid":"0,0",
+  "geometry":{
+    "coordinates":[[[-50.0,50.0],[50.0,50.0],[50.0,-50.0],[-50.0,-50.0],[-50.0,50.0]]],
+    "type":"Polygon"
+  }
+}
+```
+
+This subscription will match `UPDATE` events for the following document IDs : 
+* ID__10__30DI
+* ID_10__30DI
+* ID_30__10DI
+* ID_30_10DI
+* ID_40_0DI
+* ID__40_0DI
+* ID__20_20DI
+* ID_0__40DI
+* ID_0_40DI
+* ID_10_30DI
+* ID_20_20DI
+* ID__10_30DI
+* ID__30__10DI
+* ID__30_10DI
+* ID__20__20DI
+* ID_20__20DI
+
+
+
+#### Collection description
+```json
+{
+  "collection_name": "geodata",
+  "params": {
+    "index_name": "subs",
+    "type_name": "sub_type",
+    "id_path": "id",
+    "geometry_path": "geometry",
+    "centroid_path": "centroid",
+    "timestamp_path": "created_at"
+  }
+}
+```

--- a/arlas-subscriptions-tests/pom.xml
+++ b/arlas-subscriptions-tests/pom.xml
@@ -16,7 +16,6 @@
         <org.hamcrest.version>1.3</org.hamcrest.version>
         <io.rest-assured.version>3.3.0</io.rest-assured.version>
         <junit.version>4.12</junit.version>
-        <geojson.jackson.version>1.8.1</geojson.jackson.version>
     </properties>
 
     <dependencies>

--- a/arlas-subscriptions-tests/src/test/java/io/arlas/subscriptions/AbstractTestWithData.java
+++ b/arlas-subscriptions-tests/src/test/java/io/arlas/subscriptions/AbstractTestWithData.java
@@ -32,6 +32,7 @@ public abstract class AbstractTestWithData extends AbstractTestContext {
     public static void beforeClass() {
         try {
             DataSetTool.loadDataSet();
+            DataSetTool.loadSubscriptions();
         } catch (UnknownHostException e) {
             e.printStackTrace();
         } catch (IOException e) {
@@ -48,6 +49,7 @@ public abstract class AbstractTestWithData extends AbstractTestContext {
     @AfterClass
     public static void afterClass() {
         DataSetTool.clearDataSet();
+        DataSetTool.clearSubscriptions();
         DataSetTool.close();
     }
 }

--- a/arlas-subscriptions-tests/src/test/java/io/arlas/subscriptions/DummyIT.java
+++ b/arlas-subscriptions-tests/src/test/java/io/arlas/subscriptions/DummyIT.java
@@ -22,7 +22,6 @@ package io.arlas.subscriptions;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.squareup.okhttp.Call;
 import com.squareup.okhttp.Response;
-import io.arlas.client.Pair;
 import io.arlas.client.model.Hits;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
@@ -39,12 +38,11 @@ public class DummyIT extends AbstractTestWithData {
     @Test
     public void testArlasCollection() throws Exception {
 
-        //SEARCH REQUEST
-        Call searchCall = DataSetTool.getApiClient().buildCall("/explore/"+DataSetTool.COLLECTION_NAME+"/_search", "GET", new ArrayList<Pair>(),
+        //GEODATA SEARCH REQUEST
+        Call searchCall = DataSetTool.getApiClient().buildCall("/explore/"+DataSetTool.COLLECTION_GEODATA_NAME +"/_search", "GET", new ArrayList<>(),
                 new ArrayList<>(), null, new HashMap<>(), new HashMap<>(), new String[0], null);
         Response searchResponse = searchCall.execute();
-        String body = searchResponse.body().string();
-        Hits hits = objectMapper.readValue(body, Hits.class);
+        Hits hits = objectMapper.readValue(searchResponse.body().string(), Hits.class);
 
         Assert.assertThat("Search response is 200",
                 searchResponse.code(),
@@ -55,5 +53,21 @@ public class DummyIT extends AbstractTestWithData {
         Assert.assertThat("Search response has 595 hits",
                 hits.getTotalnb(),
                 Matchers.equalTo(595l));
+
+        //SUBSCRIPTIONS SEARCH REQUEST
+        Call subscriptionsCall = DataSetTool.getApiClient().buildCall("/explore/"+DataSetTool.COLLECTION_SUBSCRIPTIONS_NAME +"/_search", "GET", new ArrayList<>(),
+                new ArrayList<>(), null, new HashMap<>(), new HashMap<>(), new String[0], null);
+        Response subscriptionsResponse = subscriptionsCall.execute();
+        Hits subscriptionsHits = objectMapper.readValue(subscriptionsResponse.body().string(), Hits.class);
+
+        Assert.assertThat("Search response is 200",
+                subscriptionsResponse.code(),
+                Matchers.equalTo(200));
+        Assert.assertThat("Subscriptions search returns 1 hits",
+                subscriptionsHits.getNbhits(),
+                Matchers.equalTo(1l));
+        Assert.assertThat("Subscriptions search has 1 hits",
+                subscriptionsHits.getTotalnb(),
+                Matchers.equalTo(1l));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,11 @@
         <skipTests>true</skipTests>
         <surefire.version>2.20.1</surefire.version>
         <maven-shade-plugin.version>3.2.1</maven-shade-plugin.version>
+
+        <!-- LIBRARIES -->
         <cyclops.version>10.3.2</cyclops.version>
         <log4j.version>2.9.1</log4j.version>
+        <geojson.jackson.version>1.8.1</geojson.jackson.version>
 
         <!-- BACKENDS -->
         <elastic.version>6.8.1</elastic.version>

--- a/scripts/tests-integration.sh
+++ b/scripts/tests-integration.sh
@@ -19,5 +19,5 @@ SCRIPT_PATH=`cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd`
 cd ${SCRIPT_PATH}/..
 
 # TESTS SUITE
-./scripts/tests-integration-stage.sh --stage=MANAGER
 ./scripts/tests-integration-stage.sh --stage=DUMMY
+./scripts/tests-integration-stage.sh --stage=MANAGER


### PR DESCRIPTION
Just one collection indexed for integration tests purpose. More information in the REAME.md, feel free to use and modify this stuff in your tests by extending `AbstractTestWithData`.