### PR TITLE
Fix/matcher config

### DIFF
--- a/arlas-subscriptions-common/src/main/java/io/arlas/subscriptions/app/ArlasSubscriptionsConfiguration.java
+++ b/arlas-subscriptions-common/src/main/java/io/arlas/subscriptions/app/ArlasSubscriptionsConfiguration.java
@@ -19,9 +19,11 @@
 
 package io.arlas.subscriptions.app;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ArlasSubscriptionsConfiguration extends Configuration {
     @JsonProperty("kafka")
     public KafkaConfiguration kafkaConfiguration;


### PR DESCRIPTION
Added required annotation because the swagger entry in the configuration file was not declared in the POJO.