### PR TITLE
identity support in Manager

### DIFF
--- a/arlas-subscriptions-common/pom.xml
+++ b/arlas-subscriptions-common/pom.xml
@@ -33,6 +33,13 @@
             <groupId>org.locationtech.jts.io</groupId>
             <artifactId>jts-io-common</artifactId>
             <version>${jts.version}</version>
+            <!-- get rid of junit 4.10 conflicting with 4.12 -->
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/arlas-subscriptions-common/src/main/java/io/arlas/subscriptions/app/ArlasSubscriptionsConfiguration.java
+++ b/arlas-subscriptions-common/src/main/java/io/arlas/subscriptions/app/ArlasSubscriptionsConfiguration.java
@@ -51,4 +51,10 @@ public class ArlasSubscriptionsConfiguration extends Configuration {
 
     @JsonProperty("trigger-centroid-key")
     public String triggerCentroidKey;
+
+    @JsonProperty("identity-header")
+    public String identityHeader;
+
+    @JsonProperty("identity-admin")
+    public String identityAdmin;
 }

--- a/arlas-subscriptions-common/src/main/java/io/arlas/subscriptions/exception/ForbiddenException.java
+++ b/arlas-subscriptions-common/src/main/java/io/arlas/subscriptions/exception/ForbiddenException.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.subscriptions.exception;
+
+import javax.ws.rs.core.Response;
+
+public class ForbiddenException extends ArlasSubscriptionsException {
+
+    private static final long serialVersionUID = 1L;
+
+    public ForbiddenException() {
+        super();
+        status  = Response.Status.FORBIDDEN;
+    }
+
+    public ForbiddenException(String message) {
+        super(message);
+        status  = Response.Status.FORBIDDEN;
+    }
+
+    public ForbiddenException(String message, Throwable cause) {
+        super(message, cause);
+        status  = Response.Status.FORBIDDEN;
+    }
+
+}
+

--- a/arlas-subscriptions-manager/src/main/java/io/arlas/subscriptions/app/ArlasSubscriptionsManager.java
+++ b/arlas-subscriptions-manager/src/main/java/io/arlas/subscriptions/app/ArlasSubscriptionsManager.java
@@ -89,7 +89,8 @@ public class ArlasSubscriptionsManager extends Application<ArlasSubscriptionMana
         environment.lifecycle().manage(mongoDBManaged);
         environment.lifecycle().manage(elasticDBManaged);
         UserSubscriptionManagerService subscriptionManagerService = new UserSubscriptionManagerService(configuration,mongoDBManaged,elasticDBManaged);
-        UserSubscriptionManagerController subscriptionsManagerController = new UserSubscriptionManagerController(subscriptionManagerService);
+        UserSubscriptionManagerController subscriptionsManagerController = new UserSubscriptionManagerController(subscriptionManagerService,
+                configuration.identityHeader, configuration.identityAdmin);
         environment.jersey().register(subscriptionsManagerController);
     }
 }

--- a/arlas-subscriptions-manager/src/main/java/io/arlas/subscriptions/dao/ElasticUserSubscriptionDAOImpl.java
+++ b/arlas-subscriptions-manager/src/main/java/io/arlas/subscriptions/dao/ElasticUserSubscriptionDAOImpl.java
@@ -65,12 +65,12 @@ public class ElasticUserSubscriptionDAOImpl implements UserSubscriptionDAO  {
 
 
     @Override
-    public List<UserSubscription> getAllUserSubscriptions() throws ArlasSubscriptionsException {
+    public List<UserSubscription> getAllUserSubscriptions(String user) throws ArlasSubscriptionsException {
         return null;
     }
 
     @Override
-    public UserSubscription postUserSubscription(UserSubscription userSubscription) throws ArlasSubscriptionsException {
+    public UserSubscription postUserSubscription(UserSubscription userSubscription, boolean createdByAdmin) throws ArlasSubscriptionsException {
         IndexResponse response = null;
         try {
             this.jsonSchemaValidator.validJsonObjet(userSubscription.subscription.trigger);
@@ -91,7 +91,7 @@ public class ElasticUserSubscriptionDAOImpl implements UserSubscriptionDAO  {
 
     @Override
     public void putUserSubscription(UserSubscription updUserSubscription) throws ArlasSubscriptionsException {
-        postUserSubscription(updUserSubscription);
+        postUserSubscription(updUserSubscription, updUserSubscription.getCreated_by_admin());
     }
 
     @Override

--- a/arlas-subscriptions-manager/src/main/java/io/arlas/subscriptions/dao/UserSubscriptionDAO.java
+++ b/arlas-subscriptions-manager/src/main/java/io/arlas/subscriptions/dao/UserSubscriptionDAO.java
@@ -30,9 +30,9 @@ import java.util.Optional;
 public interface UserSubscriptionDAO {
     Logger LOGGER = LoggerFactory.getLogger(UserSubscriptionDAO.class);
 
-    List<UserSubscription> getAllUserSubscriptions() throws ArlasSubscriptionsException;
+    List<UserSubscription> getAllUserSubscriptions(String user) throws ArlasSubscriptionsException;
 
-    UserSubscription postUserSubscription(UserSubscription userSubscription) throws ArlasSubscriptionsException;
+    UserSubscription postUserSubscription(UserSubscription userSubscription, boolean createdByAdmin) throws ArlasSubscriptionsException;
 
     void deleteUserSubscription(String ref) throws ArlasSubscriptionsException;
 

--- a/arlas-subscriptions-manager/src/main/java/io/arlas/subscriptions/service/UserSubscriptionManagerService.java
+++ b/arlas-subscriptions-manager/src/main/java/io/arlas/subscriptions/service/UserSubscriptionManagerService.java
@@ -48,15 +48,15 @@ public class UserSubscriptionManagerService {
         this.daoIndexDatabase = new ElasticUserSubscriptionDAOImpl(configuration,elasticDBManaged,jsonSchemaValidator);
     }
 
-    public List<UserSubscription> getAllUserSubscriptions() throws ArlasSubscriptionsException {
-        return  this.daoDatabase.getAllUserSubscriptions();
+    public List<UserSubscription> getAllUserSubscriptions(String user) throws ArlasSubscriptionsException {
+        return  this.daoDatabase.getAllUserSubscriptions(user);
     }
 
-    public UserSubscription postUserSubscription(UserSubscription userSubscription) throws ArlasSubscriptionsException {
-        UserSubscription userSubscriptionForIndex = this.daoDatabase.postUserSubscription(userSubscription);
+    public UserSubscription postUserSubscription(UserSubscription userSubscription, boolean createdByAdmin) throws ArlasSubscriptionsException {
+        UserSubscription userSubscriptionForIndex = this.daoDatabase.postUserSubscription(userSubscription, createdByAdmin);
 
         try {
-            this.daoIndexDatabase.postUserSubscription(userSubscriptionForIndex);
+            this.daoIndexDatabase.postUserSubscription(userSubscriptionForIndex, createdByAdmin);
         } catch (ArlasSubscriptionsException e) {
             this.daoDatabase.deleteUserSubscription(userSubscriptionForIndex.getId());
             throw new ArlasSubscriptionsException("Index userSubscription in ES failed",e);

--- a/arlas-subscriptions-tests/src/test/java/io/arlas/subscriptions/AbstractTestContext.java
+++ b/arlas-subscriptions-tests/src/test/java/io/arlas/subscriptions/AbstractTestContext.java
@@ -28,11 +28,15 @@ public abstract class AbstractTestContext {
     static Logger LOGGER = LoggerFactory.getLogger(AbstractTestContext.class);
 
     protected static String arlasSubManagerPath;
+    protected static String identityHeader;
+    protected static String identityAdmin;
 
     public AbstractTestContext() {
     }
 
     static {
+        identityHeader = Optional.ofNullable(System.getenv("ARLAS_SUB_IDENTITY_HEADER")).orElse("");
+        identityAdmin = Optional.ofNullable(System.getenv("ARLAS_SUB_IDENTITY_ADMIN")).orElse("admin");
         String arlasSubManagerHost = Optional.ofNullable(System.getenv("ARLAS_SUB_MANAGER_HOST")).orElse("localhost");
         int arlasSubManagerPort = Integer.valueOf(Optional.ofNullable(System.getenv("ARLAS_SUB_MANAGER_PORT")).orElse("9998"));
         RestAssured.baseURI = "http://" + arlasSubManagerHost;

--- a/arlas-subscriptions-tests/src/test/java/io/arlas/subscriptions/AbstractTestWithData.java
+++ b/arlas-subscriptions-tests/src/test/java/io/arlas/subscriptions/AbstractTestWithData.java
@@ -20,11 +20,17 @@
 package io.arlas.subscriptions;
 
 import io.arlas.subscriptions.exception.ArlasSubscriptionsException;
+import io.arlas.subscriptions.model.UserSubscription;
+import org.geojson.LngLatAlt;
+import org.geojson.Polygon;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.locationtech.jts.io.ParseException;
 
 import java.io.IOException;
+import java.util.*;
 
 public abstract class AbstractTestWithData extends AbstractTestContext {
 
@@ -50,5 +56,49 @@ public abstract class AbstractTestWithData extends AbstractTestContext {
         DataSetTool.clearDataSet();
         DataSetTool.clearSubscriptions();
         DataSetTool.close();
+    }
+
+    protected Map<String, Object> generateTestSubscription() {
+        Map<String, Object> jsonAsMap = new HashMap<>();
+        jsonAsMap.put("created_by","gisaia");
+        jsonAsMap.put("active",true);
+        jsonAsMap.put("starts_at",1564578988l);
+        jsonAsMap.put("expires_at",2145913200l);
+        jsonAsMap.put("title","title");
+        UserSubscription.Hits hits = new UserSubscription.Hits();
+        hits.filter="filter";
+        hits.projection="projection";
+        UserSubscription.Subscription subscription = new UserSubscription.Subscription();
+        Map<String, Object> trigger = new HashMap<>();
+        JSONObject coverage = new JSONObject();
+        JSONArray jsonArrayExt = new JSONArray();
+        List<LngLatAlt> coords = new ArrayList<>();
+        coords.add(new LngLatAlt(-50, 50));
+        coords.add(new LngLatAlt(50, 50));
+        coords.add(new LngLatAlt(50, -50));
+        coords.add(new LngLatAlt(-50, -50));
+        coords.add(new LngLatAlt(-50, 50));
+        new Polygon(coords).getExteriorRing().forEach(lngLatAlt -> {
+            JSONArray jsonArrayLngLat = new JSONArray();
+            jsonArrayLngLat.add(0, lngLatAlt.getLongitude());
+            jsonArrayLngLat.add(1, lngLatAlt.getLatitude());
+            jsonArrayExt.add(jsonArrayLngLat);
+        });
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.add(jsonArrayExt);
+        coverage.put("type", "Polygon");
+        coverage.put("coordinates", jsonArray);
+        trigger.put("geometry", coverage);
+        trigger.put("job", Arrays.asList("Actor"));
+        trigger.put("event", Arrays.asList("UPDATE"));
+        trigger.put("correlationId","2007");
+        subscription.callback ="callback";
+        subscription.hits =hits;
+        subscription.trigger = trigger;
+        Map<String, String> userMetadatas = new HashMap<>();
+        userMetadatas.put("correlationId","2007");
+        jsonAsMap.put("userMetadatas",userMetadatas);
+        jsonAsMap.put("subscription",subscription);
+        return jsonAsMap;
     }
 }

--- a/arlas-subscriptions-tests/src/test/java/io/arlas/subscriptions/rest/UserSubscriptionAuthManagerServiceIT.java
+++ b/arlas-subscriptions-tests/src/test/java/io/arlas/subscriptions/rest/UserSubscriptionAuthManagerServiceIT.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.subscriptions.rest;
+
+import io.arlas.subscriptions.AbstractTestWithData;
+import io.arlas.subscriptions.DataSetTool;
+import io.restassured.http.ContentType;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class UserSubscriptionAuthManagerServiceIT extends AbstractTestWithData {
+
+    //
+    // Tests without identity header
+    //
+    @Test
+    public void test01GetAllUserSubscriptionsWithoutHeader() {
+        when().get(arlasSubManagerPath + "subscriptions/")
+                .then().statusCode(401);
+    }
+
+    @Test
+    public void test02GetUserSubscriptionWithoutHeader() {
+        when().get(arlasSubManagerPath + "subscriptions/1234")
+                .then().statusCode(401);
+    }
+
+    @Test
+    public void test03PostUserSubscriptionWithoutHeader() {
+        given().contentType("application/json")
+                .body(generateTestSubscription())
+                .post(arlasSubManagerPath + "subscriptions/")
+                .then().statusCode(401);
+    }
+    @Test
+    public void test04PutUserSubscriptionWithoutHeader() {
+        given().contentType("application/json")
+                .when().body(generateTestSubscription())
+                .put(arlasSubManagerPath + "subscriptions/1234")
+                .then().statusCode(401);
+    }
+
+    @Test
+    public void test05DeleteExistingUserSubscriptionWithoutHeader() {
+        when().delete(arlasSubManagerPath + "subscriptions/1234")
+                .then().statusCode(401);
+    }
+
+    //
+    // Tests with identity header value 'admin'
+    //
+
+    @Test
+    public void test06GetAllUserSubscriptionsWithHeaderAdmin() {
+        given().header(identityHeader, "admin").when()
+                .get(arlasSubManagerPath + "subscriptions/")
+                .then().statusCode(403);
+    }
+
+    @Test
+    public void test07GetUserSubscriptionWithHeaderAdmin() {
+        given().header(identityHeader, "admin").when()
+                .get(arlasSubManagerPath + "subscriptions/1234")
+                .then().statusCode(403);
+    }
+
+    @Test
+    public void test08PostUserSubscriptionWithHeaderAdmin() {
+        given().contentType("application/json")
+                .header(identityHeader, "admin").when()
+                .body(generateTestSubscription())
+                .post(arlasSubManagerPath + "subscriptions/")
+                .then().statusCode(403);
+    }
+
+    @Test
+    public void test09PutUserSubscriptionWithHeaderAdmin() {
+        given().contentType("application/json")
+                .header(identityHeader, "admin").when()
+                .body(generateTestSubscription())
+                .put(arlasSubManagerPath + "subscriptions/1234")
+                .then().statusCode(403);
+    }
+
+    @Test
+    public void test10DeleteExistingUserSubscriptionWithHeaderAdmin() {
+        given().header(identityHeader, "admin").when()
+                .delete(arlasSubManagerPath + "subscriptions/1234")
+                .then().statusCode(403);
+    }
+
+    //
+    // Tests with identity header value != {owner} (i.e. "foo")
+    //
+
+    @Test
+    public void test11GetAllUserSubscriptionsWithHeaderNotOwner() {
+        given().header(identityHeader, "foo")
+                .when().get(arlasSubManagerPath + "subscriptions/")
+                .then().statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("", empty());
+    }
+
+    @Test
+    public void test12GetUserSubscriptionWithHeaderNotOwner() {
+        given().header(identityHeader, "foo").when()
+                .get(arlasSubManagerPath + "subscriptions/1234")
+                .then().statusCode(404);
+    }
+
+    @Test
+    public void test13PostUserSubscriptionWithHeaderNotOwner() {
+        given().contentType("application/json")
+                .header(identityHeader, "foo").when()
+                .body(generateTestSubscription())
+                .post(arlasSubManagerPath + "subscriptions/")
+                .then().statusCode(403);
+    }
+
+    @Test
+    public void test14PostInvalidUserSubscriptionWithHeaderNotOwner() {
+        Map<String, Object> jsonAsMap = new HashMap<>();
+        jsonAsMap.put("created_by","gisaia");
+        given().contentType("application/json")
+                .header(identityHeader, "foo").when()
+                .body(jsonAsMap)
+                .post(arlasSubManagerPath + "subscriptions/")
+                .then().statusCode(400);
+    }
+
+    @Test
+    public void test15PutUserSubscriptionWithHeaderNotOwner() {
+        given().contentType("application/json")
+                .header(identityHeader, "foo").when()
+                .body(generateTestSubscription())
+                .put(arlasSubManagerPath + "subscriptions/1234")
+                .then().statusCode(404);
+    }
+
+    @Test
+    public void test16DeleteExistingUserSubscriptionWithHeaderNotOwner() {
+        given().header(identityHeader, "foo").when()
+                .delete(arlasSubManagerPath + "subscriptions/1234")
+                .then().statusCode(404);
+    }
+
+    //
+    // Tests with identity header value == {owner} (i.e. "gisaia")
+    //
+    @Test
+    public void test17GetAllUserSubscriptionsWithHeaderOwner() {
+        given().header(identityHeader, "gisaia").when()
+                .get(arlasSubManagerPath + "subscriptions/")
+                .then().statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("size()", is(1));
+    }
+
+    @Test
+    public void test18GetUserSubscriptionNotFound() {
+        given().header(identityHeader, "gisaia").when()
+                .get(arlasSubManagerPath + "subscriptions/666")
+                .then().statusCode(404);
+    }
+
+    @Test
+    public void test19GetUserSubscriptionWithHeaderOwner() {
+        given().header(identityHeader, "gisaia").when()
+                .get(arlasSubManagerPath + "subscriptions/1234")
+                .then().statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("id", equalTo("1234"));
+    }
+
+    @Test
+    public void test20PostInvalidUserSubscriptionWithHeaderOwner() {
+        Map<String, Object> jsonAsMap = new HashMap<>();
+        jsonAsMap.put("created_by","gisaia");
+        given().contentType("application/json")
+                .header(identityHeader, "gisaia").when()
+                .body(jsonAsMap)
+                .post(arlasSubManagerPath + "subscriptions/")
+                .then().statusCode(400);
+    }
+
+    @Test
+    public void test21PostUserSubscriptionWithHeaderOwner() throws Exception {
+        String id = given().contentType("application/json")
+                .header(identityHeader, "gisaia").when()
+                .body(generateTestSubscription())
+                .post(arlasSubManagerPath + "subscriptions/")
+                .then().statusCode(200)
+                .body("title", equalTo("title"))
+                .extract().jsonPath().get("id");
+
+        assertThat(DataSetTool.getUserSubscriptionFromMongo(id).get().title, is("title"));
+        assertThat(DataSetTool.getUserSubscriptionFromES(id).title, is("title"));
+    }
+
+    @Test
+    public void test22PutUserSubscriptionWithHeaderOwner() throws Exception {
+        given().contentType("application/json")
+                .header(identityHeader, "gisaia").when()
+                .body(generateTestSubscription())
+                .put(arlasSubManagerPath + "subscriptions/1234")
+                .then().statusCode(201)
+                .contentType(ContentType.JSON)
+                .body("title", equalTo("title"));
+
+        assertThat(DataSetTool.getUserSubscriptionFromMongo("1234").get().title, is("title"));
+        assertThat(DataSetTool.getUserSubscriptionFromES("1234").title, is("title"));
+    }
+
+    @Test
+    public void test23DeleteExistingUserSubscriptionWithHeaderOwner() throws Exception {
+        given().header(identityHeader, "gisaia").when()
+                .delete(arlasSubManagerPath + "subscriptions/1234")
+                .then()
+                .statusCode(202)
+                .contentType(ContentType.JSON)
+                .body("id", equalTo("1234"));
+
+        assertTrue(DataSetTool.getUserSubscriptionFromMongo("1234").get().getDeleted());
+        assertTrue(DataSetTool.getUserSubscriptionFromES("1234").getDeleted());
+    }
+}

--- a/conf/configuration.yaml
+++ b/conf/configuration.yaml
@@ -9,6 +9,10 @@ kafka:
   kafka-topic-subscription-events: ${KAFKA_TOPIC_SUBSCRIPTION_EVENTS:-subscription_events}
   kafka-topic-notification-orders: ${KAFKA_TOPIC_NOTIFICATION_ORDERS:-notification_orders}
 
+#################################################
+############ ARLAS ENDPOINTS      ###############
+#################################################
+
 arlas-subscriptions-basePath: ${ARLAS_SUBSCRIPTIONS_BASE_PATH:-http://localhost:9999}
 arlas-subscriptions-searchEndpoint: ${ARLAS_SUBSCRIPTIONS_SEARCH_ENDPOINT:-/arlas/explore/subscriptions/_search}
 arlas-subscriptions-subscriptionFilterRoot: gintersect={md.geometry}&f=subscription.trigger.event:eq:{operation}&f=subscription.trigger.job:eq:{collection}&f=active:eq:true&f=deleted:eq:false&f=expires_at:gt:now&f=starts_at:lte:now&sort=id
@@ -93,7 +97,10 @@ elastic:
   type: ${ARLAS_SUB_ELASTIC_TYPE:-sub_type}
 
 ########################################################
-############ Subcription DATA model                     ###############
+############ Subcription DATA model      ###############
 ########################################################
 trigger-geometry-key: ${ARLAS_SUB_GEOM_KEY:-geometry}
 trigger-centroid-key: ${ARLAS_SUB_CENT_KEY:-centroid}
+
+identity-header: ${ARLAS_SUB_IDENTITY_HEADER:-}
+identity-admin: ${ARLAS_SUB_IDENTITY_ADMIN:-admin}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -91,9 +91,9 @@ services:
       - ARLAS_SUB_ELASTIC_INDEX=subs
       - ARLAS_SUB_ELASTIC_TYPE=sub_type
       - ARLAS_SUB_TRIG_SCHEM_PATH=${ARLAS_SUB_TRIG_SCHEM_PATH}
+      - ARLAS_SUB_IDENTITY_HEADER=${ARLAS_SUB_IDENTITY_HEADER:-}
     volumes:
       - ${ARLAS_SUB_TRIG_SCHEM_PATH_LOCAL}:${ARLAS_SUB_TRIG_SCHEM_PATH}
-
     ports:
       - 9998:9998
     command: ["/opt/app/wait-for-deps.sh $$MONGO_HOST:$$MONGO_PORT $$ARLAS_SUB_ELASTIC_NODES "]

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -89,6 +89,7 @@ docker run --rm \
 	maven:3.5.0-jdk-8 \
 	mvn clean install
 echo "arlas-subscriptions:${ARLAS_SUBSCRIPTIONS_VERSION}"
+if [ "$STAGE" == "MANAGER_AUTH" ]; then run_manager;fi
 if [ "$STAGE" == "MANAGER" ]; then run_manager;fi
 if [ "$STAGE" == "MATCHER" ]; then run_matcher;fi
 if [ "$STAGE" == "DUMMY" ]; then run_dummy;fi

--- a/scripts/tests-integration-stage.sh
+++ b/scripts/tests-integration-stage.sh
@@ -78,7 +78,30 @@ function test_manager() {
             --net arlas-subscriptions_default \
             maven:3.5.0-jdk-8 \
             mvn -Dit.test=UserSubscriptionManagerServiceIT verify -DskipTests=false  -DfailIfNoTests=false
+}
 
+function test_manager_auth() {
+        export ARLAS_SUB_IDENTITY_HEADER="x-identity"
+        start_stack
+        docker run --rm \
+            -w /opt/maven \
+            -v $PWD:/opt/maven \
+            -v $HOME/.m2:/root/.m2 \
+            -e ARLAS_SUB_MANAGER_HOST="arlas-subscriptions-manager" \
+            -e ARLAS_SUB_MANAGER_PORT="9998" \
+            -e MONGO_HOST="mongodb" \
+            -e MONGO_PORT="27017" \
+            -e MONGO_DATABASE="subscription" \
+            -e ARLAS_ELASTIC_HOST="elasticsearch" \
+            -e ARLAS_SUB_ELASTIC_NODES="elasticsearch:9300" \
+            -e ARLAS_SUB_ELASTIC_SNIFFING="false" \
+            -e ARLAS_SUB_ELASTIC_INDEX="subs" \
+            -e ARLAS_SUB_ELASTIC_TYPE="sub_type"\
+            -e ARLAS_SUB_ELASTIC_CLUSTER="elasticsearch" \
+            -e ARLAS_SUB_IDENTITY_HEADER="x-identity" \
+            --net arlas-subscriptions_default \
+            maven:3.5.0-jdk-8 \
+            mvn -Dit.test=UserSubscriptionAuthManagerServiceIT verify -DskipTests=false  -DfailIfNoTests=false
 }
 
 function test_matcher() {
@@ -94,7 +117,6 @@ function test_matcher() {
             --net arlas-subscriptions_default \
             maven:3.5.0-jdk-8 \
             mvn -Dit.test=SubscriptionsMatcherIT verify -DskipTests=false  -DfailIfNoTests=false
-
 }
 
 function test_dummy() {
@@ -111,10 +133,10 @@ function test_dummy() {
             --net arlas-subscriptions_default \
             maven:3.5.0-jdk-8 \
             mvn -Dit.test=DummyIT verify -DskipTests=false  -DfailIfNoTests=false
-
 }
 
 echo "===> run integration tests"
+if [ "$STAGE" == "MANAGER_AUTH" ]; then test_manager_auth; fi
 if [ "$STAGE" == "MANAGER" ]; then test_manager; fi
 if [ "$STAGE" == "MATCHER" ]; then test_matcher; fi
 if [ "$STAGE" == "DUMMY" ]; then test_dummy; fi


### PR DESCRIPTION
partial fix #11 : if identity header name is defined then filter out on identity header value (if not, no filter is done)