### PR TITLE
Update a subscription (internal mode)

### DIFF
--- a/subscriptions-manager/src/main/java/io/arlas/subscriptions/rest/UserSubscriptionManagerEndUserController.java
+++ b/subscriptions-manager/src/main/java/io/arlas/subscriptions/rest/UserSubscriptionManagerEndUserController.java
@@ -192,7 +192,7 @@ public class UserSubscriptionManagerEndUserController extends UserSubscriptionMa
                         @QueryParam(value = "pretty") Boolean pretty
     ) throws ArlasSubscriptionsException {
         String user = getUser(headers);
-        UserSubscription userSubscription = subscriptionManagerService.getUserSubscription(id, Optional.ofNullable(user), false)
+        UserSubscription userSubscription = subscriptionManagerService.getUserSubscription(id, Optional.ofNullable(user), true)
                 .orElseThrow(() -> new NotFoundException("Subscription with id " + id + " not found for user " + user));
         subscriptionManagerService.deleteUserSubscription(userSubscription);
 
@@ -294,7 +294,7 @@ public class UserSubscriptionManagerEndUserController extends UserSubscriptionMa
             throw new ForbiddenException("Existing or updated subscription does not belong to authenticated user " + user);
         }
         return ResponseFormatter.getCreatedResponse(uriInfo.getRequestUriBuilder().build(),
-                halService.subscriptionWithLinks(subscriptionManagerService.putUserSubscription(user, oldUserSubscription, updUserSubscription), uriInfo));
+                halService.subscriptionWithLinks(subscriptionManagerService.putUserSubscription(oldUserSubscription, updUserSubscription, Optional.ofNullable(user)), uriInfo));
     }
 
     private String getUser(HttpHeaders headers) throws UnauthorizedException, ForbiddenException {

--- a/subscriptions-manager/src/main/java/io/arlas/subscriptions/service/UserSubscriptionManagerService.java
+++ b/subscriptions-manager/src/main/java/io/arlas/subscriptions/service/UserSubscriptionManagerService.java
@@ -41,6 +41,7 @@ import static io.arlas.subscriptions.app.ArlasSubscriptionsManager.MANAGER;
 
 public class UserSubscriptionManagerService {
     public final ArlasLogger logger = ArlasLoggerFactory.getLogger(UserSubscriptionManagerService.class, MANAGER);
+    private static final String UNKNOWN_USER = "unknown";
 
     private UserSubscriptionDAO daoDatabase;
     private UserSubscriptionDAO daoIndexDatabase;
@@ -73,13 +74,8 @@ public class UserSubscriptionManagerService {
     }
 
     public Optional<UserSubscription> getUserSubscription(String id, Optional<String> user, boolean deleted) throws ArlasSubscriptionsException {
-        logger.debug(String.format("User %s requests subscription %s (deleted %b)", user.orElse("unknown"), id, deleted));
+        logger.debug(String.format("User %s requests subscription %s (deleted %b)", user.orElse(UNKNOWN_USER), id, deleted));
         return this.daoDatabase.getSubscription(id, user, deleted);
-    }
-
-    public Optional<UserSubscription> getSubscription(String id, boolean deleted) throws ArlasSubscriptionsException {
-        logger.debug(String.format("Requesting subscription %s (deleted %b)", id, deleted));
-        return this.daoDatabase.getSubscription(id, Optional.empty(), deleted);
     }
 
     public void deleteUserSubscription(UserSubscription userSubscription) throws ArlasSubscriptionsException {
@@ -94,8 +90,8 @@ public class UserSubscriptionManagerService {
         }
     }
 
-    public UserSubscription putUserSubscription(String user, UserSubscription oldUserSubscription, UserSubscription updUserSubscription) throws ArlasSubscriptionsException {
-        logger.debug(String.format("User %s updates subscription %s", user, updUserSubscription.getId()));
+    public UserSubscription putUserSubscription(UserSubscription oldUserSubscription, UserSubscription updUserSubscription, Optional<String> user) throws ArlasSubscriptionsException {
+        logger.debug(String.format("User %s updates subscription %s", user.orElse(UNKNOWN_USER), updUserSubscription.getId()));
         updUserSubscription.setId(oldUserSubscription.getId());
         updUserSubscription.setCreated_at(oldUserSubscription.getCreated_at());
         updUserSubscription.setModified_at(new Date().getTime());

--- a/subscriptions-tests/src/test/java/io/arlas/subscriptions/rest/UserSubscriptionManagerAdminAuthIT.java
+++ b/subscriptions-tests/src/test/java/io/arlas/subscriptions/rest/UserSubscriptionManagerAdminAuthIT.java
@@ -20,13 +20,9 @@
 package io.arlas.subscriptions.rest;
 
 import io.arlas.subscriptions.AbstractTestWithData;
-import org.junit.FixMethodOrder;
 import org.junit.Test;
-import org.junit.runners.MethodSorters;
 import static io.restassured.RestAssured.given;
-import static io.restassured.RestAssured.when;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class UserSubscriptionManagerAdminAuthIT extends AbstractTestWithData {
 
     //
@@ -53,6 +49,22 @@ public class UserSubscriptionManagerAdminAuthIT extends AbstractTestWithData {
         given().header(identityHeader, "admin")
                 .when().get(arlasSubManagerPath + "admin/subscriptions/1234")
                 .then().statusCode(401);
-        }
-
     }
+
+    @Test
+    public void test04DeleteASubscriptionsWithIdentityHeader() {
+        given().header(identityHeader, "admin")
+                .when().delete(arlasSubManagerPath + "admin/subscriptions/1234")
+                .then().statusCode(401);
+    }
+
+    @Test
+    public void test05PutASubscriptionsWithIdentityHeader() {
+        given().header(identityHeader, "admin")
+                .contentType("application/json")
+                .body(generateTestSubscription())
+                .when().put(arlasSubManagerPath + "admin/subscriptions/foo")
+                .then().statusCode(401);
+    }
+
+}

--- a/subscriptions-tests/src/test/java/io/arlas/subscriptions/rest/UserSubscriptionManagerAdminIT.java
+++ b/subscriptions-tests/src/test/java/io/arlas/subscriptions/rest/UserSubscriptionManagerAdminIT.java
@@ -273,9 +273,7 @@ public class UserSubscriptionManagerAdminIT extends AbstractTestWithData {
     @Test
     public void testPostUserSubscription_withBadTrigger_shouldFail() {
 
-
         Map<String,Object> jsonAsMap = generateTestSubscription();
-        jsonAsMap.put("created_by", TEMP_SUBS_CREATED_BY);
         ((UserSubscription.Subscription )jsonAsMap.get("subscription")).trigger.put("job","Aviator");
         given().contentType("application/json")
                 .when().body(jsonAsMap)
@@ -341,6 +339,48 @@ public class UserSubscriptionManagerAdminIT extends AbstractTestWithData {
 
         assertTrue(DataSetTool.getUserSubscriptionFromMongo(subscriptionId).get().getDeleted());
         assertTrue(DataSetTool.getUserSubscriptionFromES(subscriptionId).getDeleted());
+    }
+
+    @Test
+    public void testPutUserSubscription_withValidSubscription_shouldUpdateIt() throws Exception {
+        given().contentType("application/json")
+                .when().body(generateTestSubscription())
+                .put(arlasSubManagerPath + "admin/subscriptions/1234")
+                .then().statusCode(201)
+                .body("title", equalTo("title"));
+
+        assertThat(DataSetTool.getUserSubscriptionFromMongo("1234").get().title, is("title"));
+        assertThat(DataSetTool.getUserSubscriptionFromES("1234").title, is("title"));
+    }
+
+    @Test
+    public void testPutUserSubscription_withUnknownId_shouldFail() throws Exception {
+        given().contentType("application/json")
+                .when().body(generateTestSubscription())
+                .put(arlasSubManagerPath + "admin/subscriptions/foo")
+                .then().statusCode(404);
+    }
+
+    @Test
+    public void testPutUserSubscription_withMissingFields_shouldFail() throws Exception {
+        Map<String, Object> jsonAsMap = new HashMap<>();
+        jsonAsMap.put("created_by","John Doe");
+
+        given().contentType("application/json")
+                .when().body(jsonAsMap)
+                .put(arlasSubManagerPath + "admin/subscriptions/foo")
+                .then().statusCode(400);
+    }
+
+    @Test
+    public void testPutUserSubscription_withBadTrigger_shouldFail() {
+
+        Map<String,Object> jsonAsMap = generateTestSubscription();
+        ((UserSubscription.Subscription )jsonAsMap.get("subscription")).trigger.put("job","Aviator");
+        given().contentType("application/json")
+                .when().body(jsonAsMap)
+                .put(arlasSubManagerPath + "admin/subscriptions/1234")
+                .then().statusCode(503);
     }
 
     private UserSubscription insertTestSubscriptionInMongo(Boolean deleted, Long createdAt) {

--- a/subscriptions-tests/src/test/java/io/arlas/subscriptions/rest/UserSubscriptionManagerEndUserIT.java
+++ b/subscriptions-tests/src/test/java/io/arlas/subscriptions/rest/UserSubscriptionManagerEndUserIT.java
@@ -208,4 +208,13 @@ public class UserSubscriptionManagerEndUserIT extends AbstractTestWithData {
                 .contentType(ContentType.JSON)
                 .body("total", equalTo(0));
     }
+
+    @Test
+    public void test15PutUserSubscriptionWithUnkownSubscription() throws Exception {
+        given().contentType("application/json")
+                .when().body(generateTestSubscription())
+                .put(arlasSubManagerPath + "subscriptions/foo")
+                .then().statusCode(404);
+    }
+
 }


### PR DESCRIPTION
Also add test in end-user mode when updating
an unkown subscription.
Also add missing test: delete a subscription in internal
mode with an identity set.
Also refactor UserSubscriptionManagerService.getUserSubscription
Fix #19